### PR TITLE
fix: Add try/catch to applySettings to prevent errored mods from stopping loading

### DIFF
--- a/megamod.user.js
+++ b/megamod.user.js
@@ -256,10 +256,14 @@
 
     function applySettings(method) {
         const settings = getSettings();
-        if (settings[method] == true) {
-            funcObj[method](true);
-        } else {
-             funcObj[method](false);
+        try {
+            if (settings[method] == true) {
+                funcObj[method](true);
+            } else {
+                funcObj[method](false);
+            }
+        } catch (error) {
+            console.log(error);
         }
     }
 


### PR DESCRIPTION
Here's a fix for the issue I mentioned in #2 [here](https://github.com/aclist/kbin-megamod/pull/2#issuecomment-1604919347), it just adds a simple try...catch block to applySettings to catch any errors when loading mods