### PR TITLE
fix (resize text): resolve various compatibility issues

### DIFF
--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -74,14 +74,6 @@ function getComputedFontSize (string) { // eslint-disable-line no-unused-vars
     if (isNaN(parseFloat(string)) === false) {
         return parseFloat(string)
     }
-    const el = document.querySelector(string)
-    if (!el) {
-        return null
-    }
-    const fontsize = document.defaultView.getComputedStyle(el).fontSize
-    let px = fontsize.split('px')[0]
-    px = parseFloat(px)
-    return px
 }
 
 //returns whether the user is currently logged in

--- a/kes.user.js
+++ b/kes.user.js
@@ -619,24 +619,12 @@ function constructMenu (json, layoutArr, isNew) {
                             numberField.setAttribute("type", fieldType);
 
                             let val
-                            let size
                             if ((modSettings[key] === undefined) || (modSettings[key] === "")) {
-                                size = getComputedFontSize(initial)
-                                if (!size) {
-                                    val = 14
-                                } else {
-                                    val = size
-                                }
+                                val = getComputedFontSize(initial)
                             } else {
-                                size = getComputedFontSize(modSettings[key])
-                                if (!size) {
-                                    val = 14
-                                } else {
-                                    val = size
-                                }
+                                val = getComputedFontSize(modSettings[key])
                             }
                             numberField.setAttribute("value", val)
-
                             numberField.setAttribute("kes-iter", it);
                             numberField.setAttribute("kes-key", key);
                             numberField.setAttribute('min', json[it].fields[i].min);

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -2,122 +2,103 @@
   "name": "Customize font size",
   "author": "minnieo",
   "version": "0.1.1",
-  "label": "Change font size",
+  "label": "Change font scale factor",
   "login": false,
   "recurs": true,
-  "desc": "Customize the font size site-wide. The window will become transparent as you increment/decrement font sizes.",
+  "desc": "Customize the font scale on a per-page/component basis.",
   "entrypoint": "resize_text",
   "namespace": "resize",
   "page": "accessibility",
-  "catch_reset": [
-    "optionHeader",
-    "optionThreads",
-    "optionComments",
-    "optionHomeSidebar",
-    "optionCreate",
-    "optionProfile",
-    "optionUserSettings",
-    "optionMessages",
-    "optionMenubar",
-    "optionNotifs",
-    "optionFooter"
-  ],
   "fields": [
     {
-      "type": "reset",
-      "key": "resetNumFields",
-      "label": "Reset values to defaults:",
-      "value": "reset"
-    },
-    {
-      "type": "number",
-      "initial": "#header.header",
+      "type": "range",
       "key": "optionHeader",
       "label": "Header:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "article.entry .content p",
+      "type": "range",
       "key": "optionThreads",
       "label": "Threads:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": ".entry-comment .content",
+      "type": "range",
       "key": "optionComments",
       "label": "Comments:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "div.page-notifications",
+      "type": "range",
       "key": "optionNotifs",
       "label": "Notifications:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "div.container form[name=\"user_settings\"",
+      "type": "range",
       "key": "optionUserSettings",
-      "label": "Settings, magazine index:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "label": "Settings",
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "aside#options menu li a, aside#options menu i",
+      "type": "range",
       "key": "optionMenubar",
       "label": "Options bars (top of pages):",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "aside#sidebar section.related-magazines",
+      "type": "range",
       "key": "optionHomeSidebar",
       "label": "Sidebars:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "form.entry-create",
+      "type": "range",
       "key": "optionCreate",
       "label": "Create (threads, mags, links, etc):",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "div.user-box",
+      "type": "range",
       "key": "optionProfile",
       "label": "User profiles:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
     },
     {
-      "type": "number",
-      "initial": "div.page-messages",
+      "type": "range",
       "key": "optionMessages",
       "label": "Inbox messages:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
     }
   ]
 }

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -12,8 +12,8 @@
   "fields": [
     {
       "type": "range",
-      "key": "optionHeader",
-      "label": "Header:",
+      "key": "optionNavbar",
+      "label": "Navbar:",
       "show_value": true,
       "initial": 4,
       "min": 1,
@@ -88,6 +88,15 @@
       "label": "User profiles:",
       "show_value": true,
       "initial": 5,
+      "min": 1,
+      "max": 10
+    },
+    {
+      "type": "range",
+      "key": "optionPopover",
+      "label": "User popover card:",
+      "show_value": true,
+      "initial": 4,
       "min": 1,
       "max": 10
     },

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -99,6 +99,15 @@
       "initial": 5,
       "min": 1,
       "max": 10
+    },
+    {
+      "type": "range",
+      "key": "optionTables",
+      "label": "Table content:",
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
     }
   ]
 }

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -39,6 +39,15 @@
     },
     {
       "type": "range",
+      "key": "optionPostComment",
+      "label": "Post comment area:",
+      "show_value": true,
+      "initial": 4,
+      "min": 1,
+      "max": 10
+    },
+    {
+      "type": "range",
       "key": "optionNotifs",
       "label": "Notifications:",
       "show_value": true,

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -18,7 +18,7 @@
     "optionProfile",
     "optionUserSettings",
     "optionMessages",
-    "optionSortBy",
+    "optionMenubar",
     "optionNotifs",
     "optionFooter"
   ],
@@ -77,8 +77,8 @@
     {
       "type": "number",
       "initial": "aside#options menu li a, aside#options menu i",
-      "key": "optionSortBy",
-      "label": "Sort by bar:",
+      "key": "optionMenubar",
+      "label": "Options bars (top of pages):",
       "step": "0.1",
       "min": "5",
       "max": "50"

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -135,6 +135,24 @@
       "initial": 5,
       "min": 1,
       "max": 10
+    },
+    {
+      "type": "range",
+      "key": "optionModlog",
+      "label": "Moderation log:",
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
+    },
+    {
+      "type": "range",
+      "key": "optionPagination",
+      "label": "Pagination footer:",
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
     }
   ]
 }

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -126,6 +126,15 @@
       "initial": 4,
       "min": 1,
       "max": 10
+    },
+    {
+      "type": "range",
+      "key": "optionAbout",
+      "label": "About pages:",
+      "show_value": true,
+      "initial": 5,
+      "min": 1,
+      "max": 10
     }
   ]
 }

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -11,7 +11,7 @@
   "page": "accessibility",
   "catch_reset": [
     "optionHeader",
-    "optionPosts",
+    "optionThreads",
     "optionComments",
     "optionHomeSidebar",
     "optionCreate",
@@ -41,8 +41,8 @@
     {
       "type": "number",
       "initial": "article.entry .content p",
-      "key": "optionPosts",
-      "label": "Posts:",
+      "key": "optionThreads",
+      "label": "Threads:",
       "step": "0.1",
       "min": "5",
       "max": "50"

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -49,7 +49,6 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         }
         /* ============= */
         /* POST CREATION PAGES */
-        /*TODO: this line is not applying */
         form[name="magazine"] * {
             font-size: ${resolveSize(settings["optionCreate"])}rem
         }

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -31,17 +31,30 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${resolveSize(settings["optionPostComment"])}rem
         }
         /* ABOUT PAGES */
-        #main[data-controller="lightbox timeago confirmation"] h1 {
+        #middle[class="page-about"] h1,
+        #middle[class="page-faq"] h1,
+        #middle[class="page-terms"] h1,
+        #middle[class="page-privacy-policy"] h1,
+        #middle[class="page-magazine-panel page-magazine-moderators"] h1,
+        #middle[class="page-federation"] h1 {
             font-size: ${resolveSize(settings["optionAbout"]) * 2.5}rem
         }
-        #main[data-controller="lightbox timeago confirmation"] #content {
+        #middle[class="page-about"] #content *,
+        #middle[class="page-faq"] #content *,
+        #middle[class="page-terms"] #content * ,
+        #middle[class="page-privacy-policy"] #content * ,
+        #middle[class="page-magazine-panel page-magazine-moderators"] #content *,
+        #middle[class="page-stats"] #content *,
+        #middle[class="page-federation"] .section:not(table) {
             font-size: ${resolveSize(settings["optionAbout"])}rem
+        }
+        #middle[class="page-federation"] .section h3 {
+            font-size: ${resolveSize(settings["optionAbout"]) * 2}rem
         }
         /* COMMENTS */
         .section.post.subject *, .entry-comment * {
             font-size: ${resolveSize(settings["optionComments"])}rem !important
         }
-        /* USER META POPOVER */
         #popover * {
             font-size: ${resolveSize(settings["optionPopover"])}rem !important
         }
@@ -64,7 +77,6 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         #content > h2 {
             font-size: ${resolveSize(settings["optionProfile"]) * 2}rem
         }
-        /* ============= */
         /* POST CREATION PAGES */
         form[name="magazine"] * {
             font-size: ${resolveSize(settings["optionCreate"])}rem
@@ -81,12 +93,10 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .entry-create * {
             font-size: ${resolveSize(settings["optionCreate"])}rem
         }
-        /* ============= */
         /* NAVBAR */
         #header :not(.icon) {
             font-size: ${resolveSize(settings["optionNavbar"])}rem
         }
-        /* ============= */
         /* SETTINGS */
         form[name="user_settings"] * {
             font-size: ${resolveSize(settings["optionUserSettings"])}rem;
@@ -97,9 +107,12 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .page-settings h2 {
             font-size: ${resolveSize(settings["optionUserSettings"]) * 2.5}rem
         }
-        /* ============= */
         /* MENUBAR OPTIONS */
-        .pills menu li, #activity menu li, aside#options menu li a, aside#options menu i, aside#options menu button span {
+        .pills menu li,
+        #activity menu li,
+        aside#options menu li a,
+        aside#options menu i,
+        aside#options menu button span {
             font-size: ${resolveSize(settings["optionMenubar"])}rem
         }
         /* INBOX NOTIFICATIONS */
@@ -121,7 +134,6 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .page-notifications > .mbin-container > main > h1 {
             font-size: ${resolveSize(settings["optionNotifs"]) * 2.5}rem !important
         }
-        /* ============= */
         /* THREADS */
         article.entry > header > h2 a {
             font-size: ${resolveSize(settings["optionThreads"]) * 1.295}rem
@@ -141,6 +153,18 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         }
         table .action {
             font-size: ${resolveSize(settings["optionTables"]) * 0.85}rem
+        }
+        /* MODLOG */
+        #middle[class="page-modlog"] .section--small.log,
+        #middle[class="page-modlog"] .alert.alert__danger {
+            font-size: ${resolveSize(settings["optionModlog"])}rem
+        }
+        #middle[class="page-modlog"] h1 {
+            font-size: ${resolveSize(settings["optionModlog"]) * 2.5}rem
+        }
+        /* PAGINATION FOOTER */
+        .pagination.section {
+            font-size: ${resolveSize(settings["optionPagination"])}rem
         }
         `;
         safeGM("addStyle", css, "resize-css")

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -125,15 +125,15 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${settings["optionNotifs"] * 2.5}px !important
         }
         /* ============= */
-        /* POSTS/THREADS */
+        /* THREADS */
         article.entry > header > h2 a {
-            font-size: ${settings["optionPosts"] * 1.295}px
+            font-size: ${settings["optionThreads"] * 1.295}px
         }
         article.entry > .content * {
-            font-size: ${settings["optionPosts"]}px
+            font-size: ${settings["optionThreads"]}px
         }
         article.entry * {
-            font-size: ${settings["optionPosts"]}px
+            font-size: ${settings["optionThreads"]}px
         }
         `;
         safeGM("removeStyle", "resize-css")

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -30,8 +30,15 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         #comment-add * {
             font-size: ${resolveSize(settings["optionPostComment"])}rem
         }
+        /* ABOUT PAGES */
+        #main[data-controller="lightbox timeago confirmation"] h1 {
+            font-size: ${resolveSize(settings["optionAbout"]) * 2.5}rem
+        }
+        #main[data-controller="lightbox timeago confirmation"] #content {
+            font-size: ${resolveSize(settings["optionAbout"])}rem
+        }
         /* COMMENTS */
-        .entry-comment * {
+        .section.post.subject *, .entry-comment * {
             font-size: ${resolveSize(settings["optionComments"])}rem !important
         }
         /* USER META POPOVER */
@@ -92,7 +99,7 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         }
         /* ============= */
         /* MENUBAR OPTIONS */
-        #activity menu li, aside#options menu li a, aside#options menu i, aside#options menu button span {
+        .pills menu li, #activity menu li, aside#options menu li a, aside#options menu i, aside#options menu button span {
             font-size: ${resolveSize(settings["optionMenubar"])}rem
         }
         /* INBOX NOTIFICATIONS */
@@ -127,6 +134,9 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         }
         /* TABLES */
         .table-responsive {
+            font-size: ${resolveSize(settings["optionTables"])}rem
+        }
+        table * {
             font-size: ${resolveSize(settings["optionTables"])}rem
         }
         table .action {

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -50,6 +50,9 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .section.user-info > ul > li {
             font-size: ${resolveSize(settings["optionProfile"])}rem
         }
+        #content h2 {
+            font-size: ${resolveSize(settings["optionProfile"]) * 2}rem
+        }
         /* ============= */
         /* POST CREATION PAGES */
         form[name="magazine"] * {
@@ -68,9 +71,9 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${resolveSize(settings["optionCreate"])}rem
         }
         /* ============= */
-        /* HEADERS */
+        /* NAVBAR */
         #header :not(.icon) {
-            font-size: ${resolveSize(settings["optionHeader"])}rem
+            font-size: ${resolveSize(settings["optionNavbar"])}rem
         }
         /* ============= */
         /* SETTINGS */

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -88,7 +88,7 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         }
         /* ============= */
         /* MENUBAR OPTIONS */
-        aside#options menu li a, aside#options menu i, aside#options menu button span {
+        #activity menu li, aside#options menu li a, aside#options menu i, aside#options menu button span {
             font-size: ${resolveSize(settings["optionMenubar"])}rem
         }
         /* INBOX NOTIFICATIONS */

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -116,6 +116,13 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         article.entry * {
             font-size: ${resolveSize(settings["optionThreads"])}rem
         }
+        /* TABLES */
+        .table-responsive {
+            font-size: ${resolveSize(settings["optionTables"])}rem
+        }
+        table .action {
+            font-size: ${resolveSize(settings["optionTables"]) * 0.85}rem
+        }
         `;
         safeGM("addStyle", css, "resize-css")
     }

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -30,7 +30,10 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .entry-comment * {
             font-size: ${resolveSize(settings["optionComments"])}rem !important
         }
-        /* ============= */
+        /* USER META POPOVER */
+        #popover * {
+            font-size: ${resolveSize(settings["optionPopover"])}rem !important
+        }
         /* PROFILE PAGES */
         .user-main > div > .user__actions * {
             font-size: ${resolveSize(settings["optionProfile"])}rem

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -26,6 +26,10 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .sidebar-subscriptions *,  #sidebar * {
             font-size: ${resolveSize(settings["optionHomeSidebar"])}rem !important
         }
+        /* POST COMMENT */
+        #comment-add * {
+            font-size: ${resolveSize(settings["optionPostComment"])}rem
+        }
         /* COMMENTS */
         .entry-comment * {
             font-size: ${resolveSize(settings["optionComments"])}rem !important

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -48,7 +48,7 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${settings["optionMessages"] * 2.5}px
         }
         /* SIDEBAR */
-        #sidebar * {
+        .sidebar-subscriptions *,  #sidebar * {
             font-size: ${settings["optionHomeSidebar"]}px !important
         }
         /* COMMENTS */

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -75,6 +75,9 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         /* ============= */
         /* POST CREATION PAGES */
         /*TODO: this line is not applying */
+        form[name="magazine"] * {
+            font-size: ${settings["optionCreate"]}px
+        }
         .entry-create > div > #entry_link_title_max_length {
             font-size: ${settings["optionCreate"]}px
         }

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -17,10 +17,10 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${resolveSize(settings["optionMessages"])}rem
         }
         .page-messages > .kbin-container > #main > h1 {
-            font-size: ${resolveSize(settings["optionMessages"])}rem
+            font-size: ${resolveSize(settings["optionMessages"]) * 2.5}rem
         }
         .page-messages > .mbin-container > #main > h1 {
-            font-size: ${resolveSize(settings["optionMessages"])}rem
+            font-size: ${resolveSize(settings["optionMessages"]) * 2.5}rem
         }
         /* SIDEBAR */
         .sidebar-subscriptions *,  #sidebar * {
@@ -79,7 +79,7 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${resolveSize(settings["optionUserSettings"])}rem;
         }
         .page-settings h2 {
-            font-size: ${resolveSize(settings["optionUserSettings"])}rem
+            font-size: ${resolveSize(settings["optionUserSettings"]) * 2.5}rem
         }
         /* ============= */
         /* MENUBAR OPTIONS */
@@ -91,24 +91,24 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${resolveSize(settings["optionNotifs"])}rem
         }
         .page-notifications > .kbin-container > main > .pills > menu > form > button {
-            font-size: ${resolveSize(settings["optionNotifs"])}rem
+            font-size: ${resolveSize(settings["optionNotifs"]) * 0.85}rem
         }
         .page-notifications > .kbin-container > main > h1 {
-            font-size: ${resolveSize(settings["optionNotifs"])}rem !important
+            font-size: ${resolveSize(settings["optionNotifs"]) * 2.5}rem !important
         }
         .page-notifications > .mbin-container > main > * {
             font-size: ${resolveSize(settings["optionNotifs"])}rem
         }
         .page-notifications > .mbin-container > main > .pills > menu > form > button {
-            font-size: ${resolveSize(settings["optionNotifs"])}rem
+            font-size: ${resolveSize(settings["optionNotifs"]) * 0.85}rem
         }
         .page-notifications > .mbin-container > main > h1 {
-            font-size: ${resolveSize(settings["optionNotifs"])}rem !important
+            font-size: ${resolveSize(settings["optionNotifs"]) * 2.5}rem !important
         }
         /* ============= */
         /* THREADS */
         article.entry > header > h2 a {
-            font-size: ${resolveSize(settings["optionThreads"])}rem
+            font-size: ${resolveSize(settings["optionThreads"]) * 1.295}rem
         }
         article.entry > .content * {
             font-size: ${resolveSize(settings["optionThreads"])}rem

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -97,8 +97,11 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         }
         /* ============= */
         /* SETTINGS */
-        .page-settings * {
-            font-size: ${settings["optionUserSettings"]}px
+        form[name="user_settings"] * {
+            font-size: ${settings["optionUserSettings"]}px;
+        }
+        form[name="user_settings"] .ts-control * {
+            font-size: ${settings["optionUserSettings"]}px;
         }
         .page-settings h2 {
             font-size: ${settings["optionUserSettings"] * 2.5}px

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -1,157 +1,127 @@
 function textResize (toggle) { // eslint-disable-line no-unused-vars
-    const modalContent = ".kes-settings-modal-content"
-    const modalContainer = ".kes-settings-modal-container"
 
-    function kesModalOpen () {
-        const kesModalContent = document.querySelector(modalContent);
-        if (kesModalContent) {
-            return true
-        } else {
-            return false
-        }
-    }
-
-    function modSelected () {
-        let state
-        document.querySelectorAll('.kes-option').forEach((mod) => {
-            if ((mod.style.opacity === "1") && mod.innerText === "Change font size") {
-                state = true
-            }
-        })
-        return state
-    }
-
-    function setOpacity (value) {
-        const kesModalContent = document.querySelector(modalContent);
-        const kesModalContainer = document.querySelector(modalContainer);
-        kesModalContent.style.opacity = value;
-        kesModalContainer.style.opacity = value;
+    function resolveSize (value) {
+        //const rem = (value - (value*0.785)*(0.935))
+        //midpoint of 5 = 0.85rem, default
+        //header is 5 rem by default
+        //threads are 4
+        const rem = 1 + ( (value - 5) * 0.15)
+        return rem
     }
 
     function resizeText () {
         const settings = getModSettings('resize');
-        let oldID = sessionStorage.getItem('modalFade');
-        clearTimeout(oldID)
-
-        if (kesModalOpen()) {
-            if (modSelected()) setOpacity(0.2)
-        }
         const css = `
         /* MESSAGES */
         .page-messages * {
-            font-size: ${settings["optionMessages"]}px
+            font-size: ${resolveSize(settings["optionMessages"])}rem
         }
         .page-messages > .kbin-container > #main > h1 {
-            font-size: ${settings["optionMessages"] * 2.5}px
+            font-size: ${resolveSize(settings["optionMessages"])}rem
         }
         .page-messages > .mbin-container > #main > h1 {
-            font-size: ${settings["optionMessages"] * 2.5}px
+            font-size: ${resolveSize(settings["optionMessages"])}rem
         }
         /* SIDEBAR */
         .sidebar-subscriptions *,  #sidebar * {
-            font-size: ${settings["optionHomeSidebar"]}px !important
+            font-size: ${resolveSize(settings["optionHomeSidebar"])}rem !important
         }
         /* COMMENTS */
         .entry-comment * {
-            font-size: ${settings["optionComments"]}px
+            font-size: ${resolveSize(settings["optionComments"])}rem !important
         }
         /* ============= */
         /* PROFILE PAGES */
         .user-main > div > .user__actions * {
-            font-size: ${settings["optionProfile"]}px
+            font-size: ${resolveSize(settings["optionProfile"])}rem
         }
         .user-box * {
-            font-size: ${settings["optionProfile"]}px
+            font-size: ${resolveSize(settings["optionProfile"])}rem
         }
         .section.user-info > ul > li a {
-            font-size: ${settings["optionProfile"]}px !important
+            font-size: ${resolveSize(settings["optionProfile"])}rem !important
         }
         .section.user-info > h3 {
-            font-size: ${settings["optionProfile"]}px !important
+            font-size: ${resolveSize(settings["optionProfile"])}rem !important
         }
         .section.user-info > ul > li {
-            font-size: ${settings["optionProfile"]}px
+            font-size: ${resolveSize(settings["optionProfile"])}rem
         }
         /* ============= */
         /* POST CREATION PAGES */
         /*TODO: this line is not applying */
         form[name="magazine"] * {
-            font-size: ${settings["optionCreate"]}px
+            font-size: ${resolveSize(settings["optionCreate"])}rem
         }
         .entry-create > div > #entry_link_title_max_length {
-            font-size: ${settings["optionCreate"]}px
+            font-size: ${resolveSize(settings["optionCreate"])}rem
         }
         .entry-create > div > div > .ts-control > * {
-            font-size: ${settings["optionCreate"]}px
+            font-size: ${resolveSize(settings["optionCreate"])}rem
         }
         .options.options--top.options-activity * {
-            font-size: ${settings["optionCreate"]}px !important
+            font-size: ${resolveSize(settings["optionCreate"])}rem !important
         }
         .entry-create * {
-            font-size: ${settings["optionCreate"]}px
+            font-size: ${resolveSize(settings["optionCreate"])}rem
         }
         /* ============= */
         /* HEADERS */
         #header :not(.icon) {
-            font-size: ${settings["optionHeader"]}px
+            font-size: ${resolveSize(settings["optionHeader"])}rem
         }
         /* ============= */
         /* SETTINGS */
         form[name="user_settings"] * {
-            font-size: ${settings["optionUserSettings"]}px;
+            font-size: ${resolveSize(settings["optionUserSettings"])}rem;
         }
         form[name="user_settings"] .ts-control * {
-            font-size: ${settings["optionUserSettings"]}px;
+            font-size: ${resolveSize(settings["optionUserSettings"])}rem;
         }
         .page-settings h2 {
-            font-size: ${settings["optionUserSettings"] * 2.5}px
+            font-size: ${resolveSize(settings["optionUserSettings"])}rem
         }
         /* ============= */
         /* MENUBAR OPTIONS */
         aside#options menu li a, aside#options menu i, aside#options menu button span {
-            font-size: ${settings["optionMenubar"]}px
+            font-size: ${resolveSize(settings["optionMenubar"])}rem
         }
         /* INBOX NOTIFICATIONS */
         .page-notifications > .kbin-container > main > * {
-            font-size: ${settings["optionNotifs"]}px
+            font-size: ${resolveSize(settings["optionNotifs"])}rem
         }
         .page-notifications > .kbin-container > main > .pills > menu > form > button {
-            font-size: ${settings["optionNotifs"] * 0.85}px
+            font-size: ${resolveSize(settings["optionNotifs"])}rem
         }
         .page-notifications > .kbin-container > main > h1 {
-            font-size: ${settings["optionNotifs"] * 2.5}px !important
+            font-size: ${resolveSize(settings["optionNotifs"])}rem !important
         }
         .page-notifications > .mbin-container > main > * {
-            font-size: ${settings["optionNotifs"]}px
+            font-size: ${resolveSize(settings["optionNotifs"])}rem
         }
         .page-notifications > .mbin-container > main > .pills > menu > form > button {
-            font-size: ${settings["optionNotifs"] * 0.85}px
+            font-size: ${resolveSize(settings["optionNotifs"])}rem
         }
         .page-notifications > .mbin-container > main > h1 {
-            font-size: ${settings["optionNotifs"] * 2.5}px !important
+            font-size: ${resolveSize(settings["optionNotifs"])}rem !important
         }
         /* ============= */
         /* THREADS */
         article.entry > header > h2 a {
-            font-size: ${settings["optionThreads"] * 1.295}px
+            font-size: ${resolveSize(settings["optionThreads"])}rem
         }
         article.entry > .content * {
-            font-size: ${settings["optionThreads"]}px
+            font-size: ${resolveSize(settings["optionThreads"])}rem
         }
         article.entry * {
-            font-size: ${settings["optionThreads"]}px
+            font-size: ${resolveSize(settings["optionThreads"])}rem
         }
         `;
-        safeGM("removeStyle", "resize-css")
         safeGM("addStyle", css, "resize-css")
-
-        if (kesModalOpen()) {
-            let timerID = setTimeout(setOpacity ,1000, 1.0);
-            sessionStorage.setItem('modalFade', timerID);
-        }
     }
 
     if (toggle) {
+        safeGM("removeStyle", "resize-css")
         resizeText();
     } else {
         safeGM("removeStyle", "resize-css")

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -50,7 +50,7 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .section.user-info > ul > li {
             font-size: ${resolveSize(settings["optionProfile"])}rem
         }
-        #content h2 {
+        #content > h2 {
             font-size: ${resolveSize(settings["optionProfile"]) * 2}rem
         }
         /* ============= */

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -104,9 +104,9 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${settings["optionUserSettings"] * 2.5}px
         }
         /* ============= */
-        /* SORT OPTIONS */
+        /* MENUBAR OPTIONS */
         aside#options menu li a, aside#options menu i, aside#options menu button span {
-            font-size: ${settings["optionSortBy"]}px
+            font-size: ${settings["optionMenubar"]}px
         }
         /* INBOX NOTIFICATIONS */
         .page-notifications > .kbin-container > main > * {


### PR DESCRIPTION
Resolves the complex of issues described in #436

Also resolves the issue described in #441 by dropping element to pt size conversion logic

Uses sliders in lieu of number fields. The value `5` corresponds to `1rem` and `4` corresponds to `0.85rem`. The majority of fields are initialized to `4` as the default. In order to make sure multiple elements on a page scale with each other (e.g., `h2` elements along with main content), some additional scaling transformations are applied to specific elements. This scale factor is largely unchanged from the original script.

While the new sliders are not granular enough to support 1:1 equivalence with the default font size on some pages (causing a very slight visual bump when the mod is enabled and defaults are applied), the effect is minor.

This also drops the MES opacity feature, as the sliders have fewer increments and it was seen as unorthodox for a mod to interfere with MES menus.