### PR TITLE
fix (expand_posts): restore functionality inside activity pages

### DIFF
--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -241,6 +241,31 @@ function getPageType () { //eslint-disable-line no-unused-vars
     return "Unknown"
 }
 
+function isIndex () {
+    const pt = getPageType();
+    switch (pt) {
+        case Mbin.Domain.Default:
+        case Mbin.Domain.Comments:
+        case Mbin.Top:
+            return true
+        default:
+            return false
+    }
+}
+
+function isThread () {
+    const pt = getPageType();
+    switch (pt) {
+        case Mbin.Thread.Comments:
+        case Mbin.Thread.Favorites:
+        case Mbin.Thread.Boosts:
+            return true
+        default:
+            return false
+    }
+}
+
+
 //sets the type of GM API being used (dot or underscore notation) based on scripthandler metadata
 let gmPrefix
 const dotPrefix = "GM."

--- a/mods/expand_posts/expand_posts.user.js
+++ b/mods/expand_posts/expand_posts.user.js
@@ -34,9 +34,15 @@ function expandPostsInit (toggle) { // eslint-disable-line no-unused-vars
         button.classList.add("btn", "btn-link", "btn__primary")
 
         button.addEventListener('click', () => {
+            let link
             if (button.dataset.expandMode === "expand") {
                 updateExpandMode(button)
-                const link = parent.querySelector('header h2 a');
+                if (isThread()) {
+                    link = window.location.href.split("/").slice(0, 8).join("/")
+                } else {
+                    const el = "header h2 a"
+                    link = parent.querySelector(el);
+                }
                 genericXMLRequest(link, update);
             } else {
                 updateExpandMode(button)

--- a/mods/hide_related/hide_related.js
+++ b/mods/hide_related/hide_related.js
@@ -1,28 +1,5 @@
 function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
 
-    function isIndex () {
-        const pt = getPageType();
-        switch (pt) {
-            case Mbin.Domain.Default:
-            case Mbin.Domain.Comments:
-            case Mbin.Top:
-                return true
-            default:
-                return false
-        }
-    }
-    function isThread () {
-        const pt = getPageType();
-        switch (pt) {
-            case Mbin.Thread.Comments:
-            case Mbin.Thread.Favorites:
-            case Mbin.Thread.Boosts:
-                return true
-            default:
-                return false
-        }
-    }
-
     function hideRelated () {
         restoreRelated();
         const settings = getModSettings("hide_related");


### PR DESCRIPTION
Resolves #476

Moves the `isThread()` and `isIndex()` functions from the `hide_related` mod to safeGM and uses these to determine if the current page is the index or inside a thread. If inside a thread, parses the `window.location` and reconcatenates the URL to fetch the original post content.