### PR TITLE
fix (user instance names): use href instead of title property

### DIFF
--- a/mods/user_instance_names/user_instance_names.user.js
+++ b/mods/user_instance_names/user_instance_names.user.js
@@ -5,7 +5,7 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
         els.forEach((el) => {
             if (el.getAttribute("data-instance") !== "true") {
                 if (el.classList.contains("user-hidden-instance")) return
-                const arr = el.getAttribute("title").split("@");
+                const arr = el.getAttribute("href").split("@");
                 const name = arr[1];
                 const remote = arr[2];
                 if (name) {


### PR DESCRIPTION
Usernames inside of threads do not necessarily contain the `title` property, so it's safer to target the underlying href.