### PR TITLE
feat: make search dialog closable by keyboard

### DIFF
--- a/helpers/kes.css
+++ b/helpers/kes.css
@@ -176,7 +176,7 @@ span.kes-update {
     padding-right: 0.5rem;
 }
 
-.kes-changelog {
+.kes-search, .kes-changelog {
     float: right;
     padding-left: 0.5rem;
     padding-right: 0.5rem;

--- a/kes.user.js
+++ b/kes.user.js
@@ -211,8 +211,23 @@ function constructMenu (json, layoutArr, isNew) {
             keyPressed = {};
         }
         if (keyPressed.Escape == true) {
+            const search = document.querySelector("#kes-search-dialog")
+            if ((search) && (search.open)) {
+                e.preventDefault();
+                search.remove();
+                return
+            }
             if (modal) {
                 modal.remove();
+            }
+            keyPressed = {};
+        }
+        if (keyPressed.Shift == true && keyPressed.Control == true && keyPressed["F"] == true) {
+            e.preventDefault();
+            if (!modal) {
+                return
+            } else {
+                document.querySelector(".kes-search i").click();
             }
             keyPressed = {};
         }
@@ -319,7 +334,7 @@ function constructMenu (json, layoutArr, isNew) {
         headerChangelogButton.appendChild(headerChangelogLink)
 
         const headerSearchButton = document.createElement('span')
-        headerSearchButton.className = 'kes-changelog'
+        headerSearchButton.className = 'kes-search'
         const headerSearchIcon = document.createElement('i')
         headerSearchIcon.className = layoutArr.header.search.icon
         headerSearchIcon.title = layoutArr.header.search.tooltip


### PR DESCRIPTION
- Makes search dialog openable via `Ctrl-Shift-F`
- Makes search dialog closable via `Escape`
- Also resolves an issue with the search dialog improperly being set to the selector used for the changelog icon