### PR TITLE
feat: cosmetic separator

### DIFF
--- a/mods/thread_separator/thread_separator.js
+++ b/mods/thread_separator/thread_separator.js
@@ -1,0 +1,15 @@
+function dividerInit (toggle) { //eslint-disable-line no-unused-vars
+    function insertSeparator () {
+        const pt = getPageType()
+        if (!isThread() && pt !== Mbin.Microblog) return
+        if (document.querySelector("#mes-thread-divider")) return
+        const top = document.querySelector(".section--top")
+        const sep = document.createElement("div")
+        top.insertAdjacentElement("beforebegin", sep)
+        sep.style.height = "11px"
+        sep.id = "mes-thread-divider"
+    }
+
+    if (toggle) insertSeparator()
+    if (!toggle) document.querySelector("#mes-thread-divider")?.remove();
+}

--- a/mods/thread_separator/thread_separator.js
+++ b/mods/thread_separator/thread_separator.js
@@ -6,7 +6,7 @@ function dividerInit (toggle) { //eslint-disable-line no-unused-vars
         const top = document.querySelector(".section--top")
         const sep = document.createElement("div")
         top.insertAdjacentElement("beforebegin", sep)
-        sep.style.height = "11px"
+        sep.style.height = "0.5rem"
         sep.id = "mes-thread-divider"
     }
 

--- a/mods/thread_separator/thread_separator.json
+++ b/mods/thread_separator/thread_separator.json
@@ -1,0 +1,11 @@
+{
+  "name": "Thread separator",
+  "author": "shazbot",
+  "version": "0.1.0",
+  "label": "Add extra padding between top post and navbar",
+  "login": false,
+  "recurs": false,
+  "desc": "The top post in a thread and microblog does not follow the tiled gap behavior of other panels onscreen. This fix inserts an extra divider between the top post and navbar to simulate the right spacing.",
+  "entrypoint": "thread_separator",
+  "page": "fixes"
+}


### PR DESCRIPTION
The top post in a thread and microblog does not follow the tiled gap behavior of other panels onscreen. This fix inserts an extra divider between the top post and navbar to simulate the right spacing.
