### PR TITLE
chore: add code of conduct and contributing docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Preamble
+This project is free and open source software (FOSS) that is improved upon through the collaborative efforts of its community.
+
+To foster a collegial and productive atmosphere, all interactions with this project and its members shall be subject to these standards.
+
+"Members" refers to all project maintainers, contributors, developers, and end-users.
+Bear in mind that members may come from different countries, age groups, and backgrounds, and have differing experience levels.
+
+# Standards
+- Do not engage in antagonistic, offensive, discriminatory, threatening, or inflammatory behavior or trolling towards other members under any circumstances.
+- Engage in professional communication and stay on topic. Keep banter and jokes to a minimum, as they are liable to be misconstrued.
+- While this project relates to the Mbin framework, it is not a forum for non-technical discussion about the content of threads you found on Mbin, or a place to post unsolicited links.
+- Do not use images, emoji reactions, or other non-verbal gags as justification for skirting the above standards.
+- Do not post offensive or inflammatory off-site content, or content violating the above standards or the terms of service of this site.
+- Do not post spam. The site operator implements anti-spam measures that may lead to your account being revoked.
+
+# Off-site content
+From time to time, it may be necessary to include off-site reference material or links. Use discretion when selecting this content and provide
+the minimum necessary for a technical discussion of the matter. Do not willfully include content that violates the above standards.
+
+# Enforcement
+Violations of the above standards will be subject to moderation decisions.
+
+Project maintainers reserve the right to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with these standards, and will communicate reasons for moderation decisions when appropriate.
+
+Depending on the nature of the violation, or if the violation is not corrected after a warning has been issued, the user may be permanently barred from further interaction with the project.
+
+# Technical support
+This project is free software, but this does not imply a guarantee of free, unlimited tech support and troubleshooting in perpetuity.
+The software is provided as-is, and no warranty is made as to its fitness for a given purpose or that it is free from defects.
+
+Project members volunteer their time. Do not disparage other members when they attempt to assist you.
+Be aware that if you cannot provide enough information when filing a ticket, this may lead to the ticket being closed as non-actionable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+Thank you for your interest in contributing to this project. Below are some basic guidelines and instructions.
+
+# Mods (scripts)
+Mods should focus on atomic features and do one thing well. If there is a need for multiple options within a mod, expose those via the JSON manifest to create granular settings.
+
+Mods should do not call other mods. If you are finding a need to call another mod from within a mod, this likely indicates a need for splitting that functionality into a public helper function 
+accessible to all mods.
+
+Mods are invoked in serial fashion by MES and their logic is walked through. Mods should not modify the main MES modal or MES itself.
+
+Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup. Once adapted to the MES framework, mods 
+are not intended to be run as standalone scripts.
+
+# API
+Please refer to the [API reference](https://aclist.github.io/kes/kes.html#_api_reference).
+
+# Conventions
+Refer to and use the .eslintrc file in the root directory for code conventions.
+
+# Best practices
+Please refer to [precautions and best practices](https://aclist.github.io/kes/kes.html#_precautions_and_best_practices).
+
+# Submitting a PR
+PRs should be made against the `testing` branch.
+
+Please refer to the [developers section](https://aclist.github.io/kes/kes.html#_developers) of the documentation.
+
+If you need to show an example of the page the mod affects, please include a real link from an active instance,
+as searching for specific pages/threads with that behavior can be time-consuming after the fact.
+
+By submitting a PR, you acknowledge that your contribution becomes part of the project and is subject to the [MIT license](https://raw.githubusercontent.com/aclist/kbin-kes/refs/heads/main/LICENSE).
+Your contribution may be modified at will by project maintainers at a later date.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,7 @@ accessible to all mods.
 
 Mods are invoked in serial fashion by MES and their logic is walked through. Mods should not modify the main MES modal or MES itself.
 
-Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup. Once adapted to the MES framework, mods 
-are not intended to be run as standalone scripts.
+Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup. Once adapted to the MES framework, mods are not intended to be run as standalone scripts.
 
 # API
 Please refer to the [API reference](https://aclist.github.io/kes/kes.html#_api_reference).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Mods should focus on atomic features and do one thing well. If there is a need f
 
 Mods should do not call other mods. If you are finding a need to call another mod from within a mod, this likely indicates a need for splitting that functionality into a public helper function accessible to all mods.
 
-Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup. Additionally, your mod will need some
-teardown logic (remove injected elements, clean up, etc.) that will be automatically called when the script is disabled by the user.
+Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup.
+Additionally, your mod will need some teardown logic (remove injected elements, clean up, etc.) that will be automatically called when the script is disabled by the user.
 Once adapted to the MES framework, mods are not intended to be run as standalone scripts.
 
 # API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,7 @@ Thank you for your interest in contributing to this project. Below are some basi
 # Mods (scripts)
 Mods should focus on atomic features and do one thing well. If there is a need for multiple options within a mod, expose those via the JSON manifest to create granular settings.
 
-Mods should do not call other mods. If you are finding a need to call another mod from within a mod, this likely indicates a need for splitting that functionality into a public helper function 
-accessible to all mods.
+Mods should do not call other mods. If you are finding a need to call another mod from within a mod, this likely indicates a need for splitting that functionality into a public helper function accessible to all mods.
 
 Mods are invoked in serial fashion by MES and their logic is walked through. Mods should not modify the main MES modal or MES itself.
 
@@ -24,8 +23,7 @@ PRs should be made against the `testing` branch.
 
 Please refer to the [developers section](https://aclist.github.io/kes/kes.html#_developers) of the documentation.
 
-If you need to show an example of the page the mod affects, please include a real link from an active instance,
-as searching for specific pages/threads with that behavior can be time-consuming after the fact.
+If you need to show an example of the page the mod affects, please include a real link from an active instance, as searching for specific pages/threads with that behavior can be time-consuming after the fact.
 
 By submitting a PR, you acknowledge that your contribution becomes part of the project and is subject to the [MIT license](https://raw.githubusercontent.com/aclist/kbin-kes/refs/heads/main/LICENSE).
 Your contribution may be modified at will by project maintainers at a later date.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ Mods should focus on atomic features and do one thing well. If there is a need f
 Mods should do not call other mods. If you are finding a need to call another mod from within a mod, this likely indicates a need for splitting that functionality into a public helper function 
 accessible to all mods.
 
-Mods are invoked in serial fashion by MES and their logic is walked through. Mods should not modify the main MES modal or MES itself.
-
-Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup. Once adapted to the MES framework, mods 
-are not intended to be run as standalone scripts.
+Because mods are ingested into MES as functions, the entire script should be wrapped in an entry function and be devoid of GreaseMonkey headers or other markup. Additionally, your mod will need some
+teardown logic (remove injected elements, clean up, etc.) that will be automatically called when the script is disabled by the user.
+Once adapted to the MES framework, mods are not intended to be run as standalone scripts.
 
 # API
 Please refer to the [API reference](https://aclist.github.io/kes/kes.html#_api_reference).


### PR DESCRIPTION
`CONTRIBUTING.md` has links currently pointing to the old documentation, but this will have to be updated following #454