### PR TITLE
fix: prevent adding CSS to document head with identical ID

### DIFF
--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -113,6 +113,10 @@ function clearLoader (id) { // eslint-disable-line no-unused-vars
 
 //adds custom CSS to the document head by named ID
 function addCustomCSS (css, id) {
+    if (document.head.querySelector(`style[id="${id}"]`)) {
+        log(`CSS with id '${id}' already exists, skipping`, Log.Warn)
+        return
+    }
     const style = document.createElement('style');
     style.id = id;
     style.innerHTML = css;


### PR DESCRIPTION
Resolves the issue discussed in #501 regarding multiple stylesheets stacking on top of each other.

Preferably, mods should prefix the mod name in front of each sheet ID when calling safeGM, e.g., `softblock-custom-css` rather than vague descriptors like `hide-table`.