### PR TITLE
chore: move instance names mods

### DIFF
--- a/mods/mag_instance_names/mag_instance_names.json
+++ b/mods/mag_instance_names/mag_instance_names.json
@@ -3,9 +3,9 @@
   "author": "artillect",
   "version": "0.1",
   "label": "Magazine instance names",
-  "desc": "Show instance names next to magazines",
+  "desc": "Shows instance names next to magazines. Overcomes limitations in the native Mbin setting. This will override the default behavior.",
   "login": false,
   "recurs": true,
   "entrypoint": "mag_instance_names",
-  "page": "general"
+  "page": "fixes"
 }

--- a/mods/user_instance_names/user_instance_names.json
+++ b/mods/user_instance_names/user_instance_names.json
@@ -3,9 +3,9 @@
   "author": "artillect",
   "version": "0.1",
   "label": "User instance names",
-  "desc": "Shows instance names next to users if they are not on your home instance",
+  "desc": "Shows instance names next to users if they are not on your home instance. Overcomes limitations in the native Mbin setting. This will override the default behavior.",
   "entrypoint": "user_instance_names",
   "recurs": true,
   "login": false,
-  "page": "general"
+  "page": "fixes"
 }


### PR DESCRIPTION
Alternative for: https://github.com/aclist/kbin-kes/discussions/362#discussioncomment-12490680

- Moves the two mods to the `Fixes` page
- Clarifies the description (mods override the default behavior--no need to disable the native setting)