### PR TITLE
chore: updated the instance list

### DIFF
--- a/build/scripts/gen_kes.sh
+++ b/build/scripts/gen_kes.sh
@@ -153,13 +153,12 @@ owner=$(get_owner)
 slug="${owner}/kbin-kes"
 
 instances=(
-    "https://kbin.social/*"
     "https://kbin.earth/*"
-    "https://lab2.kbin.pub/*"
-    "https://lab3.kbin.pub/*"
     "https://fedia.io/*"
-    "https://karab.in/*"
-    "https://kbin.cafe/*"
+    "https://kbin.melroy.org/*"
+    "https://moist.catsweat.com/*"
+    "https://thebrainbin.org/*"
+    "https://gehirneimer.de/*"
 )
 grants=(
     "addStyle"

--- a/kes.user.js
+++ b/kes.user.js
@@ -5,13 +5,12 @@
 // @version      5.0.0-beta.6
 // @description  Kbin Enhancement Suite
 // @author       aclist
-// @match        https://kbin.social/*
 // @match        https://kbin.earth/*
-// @match        https://lab2.kbin.pub/*
-// @match        https://lab3.kbin.pub/*
 // @match        https://fedia.io/*
-// @match        https://karab.in/*
-// @match        https://kbin.cafe/*
+// @match        https://kbin.melroy.org/*
+// @match        https://moist.catsweat.com/*
+// @match        https://thebrainbin.org/*
+// @match        https://gehirneimer.de/*
 // @grant        GM_addStyle
 // @grant        GM_getResourceText
 // @grant        GM_xmlhttpRequest


### PR DESCRIPTION
The list of instances MES should run on was outdated. I've replaced it with all the instances listed on fedidb.org which have 10 or more monthly active users, excluding rimworld.gallery.