### PR TITLE
feat: document elementFactory()

### DIFF
--- a/docs/source/funcs.rst
+++ b/docs/source/funcs.rst
@@ -19,6 +19,16 @@ Utility functions
    :param string id: unique ID of the stylesheet
    :rtype: undefined
 
+.. js:function:: elementFactory(element, id, classname)
+
+   Simplifies creation of HTMLElements by abstracting creation and setting up selectors
+   into a single function call. The `id` and `classname` parameters are optional.
+
+   :param string element: the type of HTMLElement to create.
+   :param string id: the name to use for the id selector.
+   :param string classname: the name to use for the class selector.
+   :rtype: HTMLElement
+
 .. js:function:: genericXMLRequest(url, callback)
 
    This is a further abstraction of :js:func:`safeGM.xmlhttpRequest`

--- a/docs/source/funcs.rst
+++ b/docs/source/funcs.rst
@@ -31,7 +31,7 @@ Utility functions
 
 .. js:function:: genericXMLRequest(url, callback)
 
-   This is a further abstraction of :js:func:`safeGM.xmlhttpRequest`
+   This is a further abstraction of :js:func:`safeGM.xmlHttpRequest`
    intended for when you only need to perform a generic GET request on a remote page to retrieve it.
    This utility function obviates the need to set up an object, as properties are pre-filled. (See function definition below)
 
@@ -258,7 +258,7 @@ In the context of MES, calling safeGM is thus a safer, simpler, and more cross-p
    :param value: string, int, or bool
    :rtype: undefined
 
-.. js:method:: xmlhttpRequest(details)
+.. js:method:: xmlHttpRequest(details)
 
    Greasemonkey's custom implementation of XMLHttpRequest with CORS support.
 

--- a/helpers/lib.js
+++ b/helpers/lib.js
@@ -452,6 +452,13 @@ function isThread () { // eslint-disable-line no-unused-vars
     }
 }
 
+function elementFactory (el, id=null, classname=null) { // eslint-disable-line no-unused-vars
+    const e = document.createElement(el)
+    if (id != null ) e.id = id
+    if (classname != null) e.className = classname
+    return e
+}
+
 function getTheme () { // eslint-disable-line no-unused-vars
     let theme = undefined
     document.querySelector("body").classList.forEach((c) => {

--- a/helpers/lib.js
+++ b/helpers/lib.js
@@ -452,13 +452,6 @@ function isThread () { // eslint-disable-line no-unused-vars
     }
 }
 
-function elementFactory (el, id=null, classname=null) { // eslint-disable-line no-unused-vars
-    const e = document.createElement(el)
-    if (id != null ) e.id = id
-    if (classname != null) e.className = classname
-    return e
-}
-
 function getTheme () { // eslint-disable-line no-unused-vars
     let theme = undefined
     document.querySelector("body").classList.forEach((c) => {


### PR DESCRIPTION
This is a utility function that simplifies setting up ad-hoc HTMLElements by creating the element and setting up its selectors in one pass.

This PR adds documentation to Sphinx describing how to use it. (Apparently, the function itself was already added out-of-band in `testing`).

```
>> elementFactory("div", "myid", "myclass")
<span id="myid" class="myclass">
```